### PR TITLE
Implement metadata and frame extraction endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ A collection of small video processing tools built around `ffmpeg` with a minima
 
 ## Features
 
-- **Extract first and last frames**: Upload a video and download its first frame.
+- **Extract first and last frames**: `/upload` returns the first frame of the uploaded video.
+- **Video metadata**: `/metadata` returns JSON metadata extracted with `ffprobe`.
+- **Frame extraction**: `/extract_frames` extracts frames at a given interval and returns them as a ZIP file.
 
 More tools can be added as standalone scripts in the `tools` directory.
 
@@ -19,6 +21,6 @@ More tools can be added as standalone scripts in the `tools` directory.
    ```bash
    python server.py
    ```
-4. Open [http://localhost:5000](http://localhost:5000) in a browser and upload a video file.
+4. Open [http://localhost:5000](http://localhost:5000) in a browser to use the simple uploader.
 
-Extracted frames will be saved in the `outputs` folder.
+Uploaded files and extracted frames are saved in the `uploads` and `outputs` folders respectively.

--- a/server.py
+++ b/server.py
@@ -1,6 +1,9 @@
-from flask import Flask, request, send_file, send_from_directory
+from flask import Flask, request, send_file, send_from_directory, jsonify
 import os
+import uuid
+import shutil
 from tools.extract_first_last_frame import extract_first_last_frames
+from tools.video_helpers import get_video_metadata, extract_frames
 
 app = Flask(__name__)
 UPLOAD_FOLDER = os.path.join(os.getcwd(), "uploads")
@@ -17,6 +20,39 @@ def upload_video():
     file.save(input_path)
     first_frame, _ = extract_first_last_frames(input_path, OUTPUT_FOLDER)
     return send_file(first_frame, mimetype="image/jpeg")
+
+
+@app.route("/metadata", methods=["POST"])
+def video_metadata():
+    file = request.files.get("file")
+    if not file:
+        return "No file uploaded", 400
+    os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+    filename = f"{uuid.uuid4()}{os.path.splitext(file.filename)[1]}"
+    input_path = os.path.join(UPLOAD_FOLDER, filename)
+    file.save(input_path)
+    data = get_video_metadata(input_path)
+    return jsonify(data)
+
+
+@app.route("/extract_frames", methods=["POST"])
+def frames_endpoint():
+    file = request.files.get("file")
+    interval = request.form.get("interval", type=float)
+    mode = request.form.get("mode", "frames")
+    if not file or interval is None:
+        return "Missing file or interval", 400
+
+    os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+    filename = f"{uuid.uuid4()}{os.path.splitext(file.filename)[1]}"
+    input_path = os.path.join(UPLOAD_FOLDER, filename)
+    file.save(input_path)
+
+    frames_dir, _ = extract_frames(input_path, OUTPUT_FOLDER, interval, mode)
+
+    zip_basename = os.path.join(OUTPUT_FOLDER, str(uuid.uuid4()))
+    zip_path = shutil.make_archive(zip_basename, "zip", frames_dir)
+    return send_file(zip_path, mimetype="application/zip", as_attachment=True, download_name="frames.zip")
 
 
 @app.route("/")

--- a/tools/video_helpers.py
+++ b/tools/video_helpers.py
@@ -1,0 +1,78 @@
+import os
+import subprocess
+import json
+import uuid
+import glob
+
+
+def get_video_metadata(input_path):
+    """Return metadata for a video using ffprobe."""
+    result = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "quiet",
+            "-print_format",
+            "json",
+            "-show_format",
+            "-show_streams",
+            input_path,
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def extract_frames(input_path, output_root, interval, mode="frames"):
+    """Extract frames from a video at a given interval.
+
+    Parameters
+    ----------
+    input_path : str
+        Path to the input video file.
+    output_root : str
+        Directory where extracted frames should be saved.
+    interval : int or float
+        Interval between frames. Interpretation depends on ``mode``.
+    mode : str
+        Either ``"frames"`` to grab every Nth frame or ``"seconds"`` to grab
+        one frame every N seconds.
+    Returns
+    -------
+    str
+        Directory containing the extracted frames.
+    list[str]
+        List of frame file paths.
+    """
+
+    output_dir = os.path.join(output_root, str(uuid.uuid4()))
+    os.makedirs(output_dir, exist_ok=True)
+
+    if mode == "frames":
+        filter_str = f"select=not(mod(n\,{int(interval)}))"
+    else:  # seconds
+        filter_str = f"fps=1/{float(interval)}"
+
+    frame_pattern = os.path.join(output_dir, "frame_%05d.jpg")
+
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-i",
+            input_path,
+            "-vf",
+            filter_str,
+            "-vsync",
+            "vfr",
+            frame_pattern,
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+    frames = sorted(glob.glob(os.path.join(output_dir, "frame_*.jpg")))
+    return output_dir, frames


### PR DESCRIPTION
## Summary
- implement utility helpers for getting video metadata and extracting frames
- extend `server.py` with `/metadata` and `/extract_frames`
- document new endpoints in README

## Testing
- `python -m py_compile server.py tools/extract_first_last_frame.py tools/video_helpers.py`
