### PR TITLE
Add frame extraction features to UI and server

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,10 +1,54 @@
-from flask import Flask, request, send_file, send_from_directory
+from flask import Flask, request, send_file, send_from_directory, jsonify
 import os
+import subprocess
+import uuid
+import shutil
+import json
 from tools.extract_first_last_frame import extract_first_last_frames
+from tools.extract_frames import extract_frames
 
 app = Flask(__name__)
 UPLOAD_FOLDER = os.path.join(os.getcwd(), "uploads")
 OUTPUT_FOLDER = os.path.join(os.getcwd(), "outputs")
+
+
+def video_metadata(input_path):
+    """Return basic video metadata using ffprobe."""
+    result = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=width,height,avg_frame_rate,sample_aspect_ratio",
+            "-show_entries",
+            "format=format_name",
+            "-of",
+            "json",
+            input_path,
+        ],
+        stdout=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+    data = json.loads(result.stdout)
+    stream = data["streams"][0]
+    width = int(stream.get("width", 0))
+    height = int(stream.get("height", 0))
+    fps_str = stream.get("avg_frame_rate", "0/1")
+    num, den = map(int, fps_str.split("/"))
+    fps = num / den if den else 0
+    fmt = data["format"].get("format_name", "")
+    par = stream.get("sample_aspect_ratio", "")
+    return {
+        "width": width,
+        "height": height,
+        "fps": fps,
+        "format": fmt,
+        "pixel_aspect_ratio": par,
+    }
 
 
 @app.route("/upload", methods=["POST"])
@@ -17,6 +61,38 @@ def upload_video():
     file.save(input_path)
     first_frame, _ = extract_first_last_frames(input_path, OUTPUT_FOLDER)
     return send_file(first_frame, mimetype="image/jpeg")
+
+
+@app.route("/metadata", methods=["POST"])
+def metadata():
+    file = request.files.get("file")
+    if not file:
+        return "No file uploaded", 400
+    os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+    temp_path = os.path.join(UPLOAD_FOLDER, f"{uuid.uuid4()}_{file.filename}")
+    file.save(temp_path)
+    try:
+        meta = video_metadata(temp_path)
+    finally:
+        os.remove(temp_path)
+    return jsonify(meta)
+
+
+@app.route("/extract_frames", methods=["POST"])
+def extract_frames_route():
+    file = request.files.get("file")
+    if not file:
+        return "No file uploaded", 400
+    interval = request.form.get("interval", type=float, default=1)
+    mode = request.form.get("mode", "seconds")
+    os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+    input_path = os.path.join(UPLOAD_FOLDER, f"{uuid.uuid4()}_{file.filename}")
+    file.save(input_path)
+
+    frame_dir = extract_frames(input_path, OUTPUT_FOLDER, interval, mode)
+    zip_base = os.path.join(OUTPUT_FOLDER, str(uuid.uuid4()))
+    zip_path = shutil.make_archive(zip_base, "zip", frame_dir)
+    return send_file(zip_path, as_attachment=True, download_name="frames.zip")
 
 
 @app.route("/")

--- a/static/index.html
+++ b/static/index.html
@@ -2,17 +2,65 @@
 <html>
   <body>
     <input type="file" id="fileInput" />
+    <div id="metadata"></div>
+    <label>
+      Interval: <input type="number" id="interval" value="1" min="1" />
+    </label>
+    <select id="mode">
+      <option value="seconds">Seconds</option>
+      <option value="frames">Frames</option>
+    </select>
+    <button id="extractBtn">Extract Frames</button>
     <img id="frame" alt="First frame will appear here" />
     <script>
       const input = document.getElementById('fileInput');
       const img = document.getElementById('frame');
+      const metadataDiv = document.getElementById('metadata');
+      const extractBtn = document.getElementById('extractBtn');
+      const intervalInput = document.getElementById('interval');
+      const modeSelect = document.getElementById('mode');
+      let currentFile;
+
       input.addEventListener('change', async () => {
-        const file = input.files[0];
-        const formData = new FormData();
-        formData.append('file', file);
-        const res = await fetch('/upload', { method: 'POST', body: formData });
+        currentFile = input.files[0];
+        if (!currentFile) return;
+
+        // Preview first frame
+        const previewForm = new FormData();
+        previewForm.append('file', currentFile);
+        let res = await fetch('/upload', { method: 'POST', body: previewForm });
         const blob = await res.blob();
         img.src = URL.createObjectURL(blob);
+
+        // Fetch metadata
+        const metaForm = new FormData();
+        metaForm.append('file', currentFile);
+        res = await fetch('/metadata', { method: 'POST', body: metaForm });
+        if (res.ok) {
+          const meta = await res.json();
+          metadataDiv.innerText = `Width: ${meta.width}, Height: ${meta.height}, FPS: ${meta.fps}, Format: ${meta.format}, Pixel AR: ${meta.pixel_aspect_ratio}`;
+        } else {
+          metadataDiv.innerText = 'Failed to load metadata';
+        }
+      });
+
+      extractBtn.addEventListener('click', async () => {
+        if (!currentFile) return;
+        const formData = new FormData();
+        formData.append('file', currentFile);
+        formData.append('interval', intervalInput.value);
+        formData.append('mode', modeSelect.value);
+        const res = await fetch('/extract_frames', { method: 'POST', body: formData });
+        if (res.ok) {
+          const blob = await res.blob();
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = 'frames.zip';
+          document.body.appendChild(a);
+          a.click();
+          a.remove();
+        }
       });
     </script>
   </body>

--- a/tools/extract_frames.py
+++ b/tools/extract_frames.py
@@ -1,0 +1,66 @@
+import os
+import subprocess
+import uuid
+
+
+def extract_frames(input_path, output_dir, interval=1, mode="seconds"):
+    """Extract frames from a video at a given interval.
+
+    Args:
+        input_path (str): Path to the input video.
+        output_dir (str): Directory where frames will be saved.
+        interval (float): Interval value depending on ``mode``.
+        mode (str): ``"seconds"`` to grab one frame every ``interval`` seconds or
+            ``"frames"`` to grab every ``interval``-th frame.
+    Returns:
+        str: Directory containing the extracted frames.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    video_id = str(uuid.uuid4())
+    frame_dir = os.path.join(output_dir, video_id)
+    os.makedirs(frame_dir, exist_ok=True)
+    output_pattern = os.path.join(frame_dir, "%04d.jpg")
+
+    if mode == "seconds":
+        vf = f"fps=1/{interval}"
+        cmd = ["ffmpeg", "-y", "-i", input_path, "-vf", vf, output_pattern]
+    else:
+        vf = f"select=not(mod(n\\,{int(interval)}))"
+        cmd = [
+            "ffmpeg",
+            "-y",
+            "-i",
+            input_path,
+            "-vf",
+            vf,
+            "-vsync",
+            "vfr",
+            output_pattern,
+        ]
+
+    subprocess.run(cmd, check=True)
+    return frame_dir
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Extract frames from a video")
+    parser.add_argument("input", help="Path to input video")
+    parser.add_argument("output_dir", help="Directory to save frames")
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=1,
+        help="Interval in seconds or frames depending on mode",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["seconds", "frames"],
+        default="seconds",
+        help="Extraction mode",
+    )
+    args = parser.parse_args()
+
+    dir_path = extract_frames(args.input, args.output_dir, args.interval, args.mode)
+    print("Frames saved to", dir_path)


### PR DESCRIPTION
## Summary
- implement metadata and frame extraction endpoints in Flask server
- add utility script for extracting frames with ffmpeg
- overhaul static index page with controls for interval/mode
- show metadata and keep frame preview functionality

## Testing
- `python -m py_compile server.py tools/extract_frames.py`
- `python -m py_compile tools/extract_first_last_frame.py`